### PR TITLE
fix: Use correct step names when defining outputs in promote workflow.

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -20,8 +20,8 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     outputs:
-      prerelease-tag: ${{ steps.extract-versions.outputs.prerelease-tag }}
-      release-tag: ${{ steps.extract-versions.outputs.release-tag }}
+      prerelease-tag: ${{ steps.version.outputs.prerelease-tag }}
+      release-tag: ${{ steps.version.outputs.release-tag }}
     strategy:
       matrix:
         version: [prerelease, release]


### PR DESCRIPTION
Calling this a "fix" to ensure we bump a version and make a release PR so I can test this.